### PR TITLE
Add mruby builds

### DIFF
--- a/.buildkite/bin/test-mruby
+++ b/.buildkite/bin/test-mruby
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MRUBY_VERSION=$1
+
+MRUBY_CONFIG=/root/build_config.rb .buildkite/bin/install-ruby $MRUBY_VERSION
+
+ruby spec/run.rb

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,3 +50,23 @@ steps:
   - label: 'Taylor - v0.3.14.1'
     commands:
       - .buildkite/bin/test-taylor v0.3.14.1
+
+  - label: 'MRuby - 3.4'
+    commands:
+      - .buildkite/bin/test-mruby 3.4.0
+
+  - label: 'MRuby - 3.3'
+    commands:
+      - .buildkite/bin/test-mruby 3.3.0
+
+  - label: 'MRuby - 3.2'
+    commands:
+      - .buildkite/bin/test-mruby 3.2.0
+
+  - label: 'MRuby - 3.1'
+    commands:
+      - .buildkite/bin/test-mruby 3.1.0
+
+  - label: 'MRuby - 3.0'
+    commands:
+      - .buildkite/bin/test-mruby 3.0.0


### PR DESCRIPTION
I have compiled mruby with `mattn/mruby-require` so we don't have to squash all the files into one, but it does work that way too. I tested it manually.